### PR TITLE
Fix headless not working

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,6 @@ You can set various options in `config.js` file.
 
  - You can send common emojis directly by typing `:smile:`, `:lol:`, `:happy:`, `:love:`, `:wink:` OR `;-)`, `:-)`, `<3`, etc
 
-## Issues ##
-
-- Currently does not seem to work in invisible/headless mode (seems to be a bug in puppeteer currently). So you have to set `window` option to `true` in config.js file.
-
 ## Contribute ##
 
 You are welcome to contribute to this project.

--- a/chat.js
+++ b/chat.js
@@ -66,10 +66,9 @@ process.on("unhandledRejection", (reason, p) => {
     const tmpPath = path.resolve(__dirname, config.data_dir);
     const networkIdleTimeout = 30000;
     const stdin = process.stdin;
-    const headless = !config.window;
 
     const browser = await puppeteer.launch({
-      headless: headless,
+      headless: fs.existsSync(tmpPath),
       executablePath: executablePath,
       userDataDir: tmpPath,
       args: [
@@ -82,6 +81,13 @@ process.on("unhandledRejection", (reason, p) => {
     });
 
     const page = await browser.newPage();
+    await page.setUserAgent('Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Safari/537.36');
+    await page.setViewport({width: 1240, height:640})
+    await page.setRequestInterception(true);
+    
+    page.on('request', request => {
+      request.continue();
+    });
 
     print(gradient.rainbow('Initializing...\n'));
 

--- a/chat.js
+++ b/chat.js
@@ -1,4 +1,4 @@
-#!/usr/bin / env node
+#!/usr/bin/env node
 
 const puppeteer = require('puppeteer');
 const notifier = require('node-notifier');

--- a/config.js
+++ b/config.js
@@ -10,10 +10,6 @@ module.exports = {
     // and re-authorize Whatsapp.
     data_dir: './tmp',
 
-    // When true, Chrome browser window will be shown. When false, it will be hidden
-    window: true,
-
-
     ////////////////////////////////////////////////////////////////
     // CHAT SETTINGS
     ////////////////////////////////////////////////////////////////


### PR DESCRIPTION
It seen that it only works headless if setRequestInterception is true and there is and event listener on the requests  :open_hands:

I really don't know why, but that way is working